### PR TITLE
Update FunctionSignatureMap.php

### DIFF
--- a/src/Phan/Language/Internal/FunctionSignatureMap.php
+++ b/src/Phan/Language/Internal/FunctionSignatureMap.php
@@ -1937,7 +1937,7 @@ return [
 'expect_expectl' => ['int', 'expect'=>'', 'cases'=>'array', 'match='=>'array'],
 'expect_popen' => ['resource', 'command'=>'string'],
 'exp' => ['float', 'number'=>'float'],
-'explode' => ['array', 'separator'=>'string', 'str'=>'string', 'limit='=>'int'],
+'explode' => ['string[]|false', 'separator'=>'string', 'str'=>'string', 'limit='=>'int'],
 'expm1' => ['float', 'number'=>'float'],
 'extension_loaded' => ['bool', 'extension_name'=>'string'],
 'extract' => ['int', '&rw_var_array'=>'array', 'extract_type='=>'int', 'prefix='=>'string'],


### PR DESCRIPTION
Updated explode() return type from 'array' to 'string[]|false' per http://www.php.net/manual/en/function.explode.php.